### PR TITLE
[fix][grafana-mixin] many-to-one require explicit grouping

### DIFF
--- a/charts/grafana-mixin/Chart.yaml
+++ b/charts/grafana-mixin/Chart.yaml
@@ -28,7 +28,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -57,4 +57,4 @@ annotations:
     url: https://keybase.io/nlamirault/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fix
-      description: Normalise dashboards ConfigMaps using ConfigMapList
+      description: alert grouping expression

--- a/charts/grafana-mixin/README.md
+++ b/charts/grafana-mixin/README.md
@@ -1,6 +1,6 @@
 # grafana-mixin
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.0.0](https://img.shields.io/badge/AppVersion-9.0.0-informational?style=flat-square)
+![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.0.0](https://img.shields.io/badge/AppVersion-9.0.0-informational?style=flat-square)
 
 A Helm chart for Grafana Mixin
 

--- a/charts/grafana-mixin/templates/alerts.yaml
+++ b/charts/grafana-mixin/templates/alerts.yaml
@@ -20,8 +20,12 @@ spec:
         message: '{{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job {{`}}`}}/{{`{{`}} $labels.handler {{`}}`}} is
           experiencing {{`{{`}} $value | humanize {{`}}`}}% errors'
       expr: |
-        100 * namespace_job_handler_statuscode:grafana_http_request_duration_seconds_count:rate5m{handler!~"/api/datasources/proxy/:id.*|/api/ds/query|/api/tsdb/query", status_code=~"5.."}
-        / ignoring (status_code)
+        100
+        *
+        namespace_job_handler_statuscode:grafana_http_request_duration_seconds_count:rate5m{handler!~"/api/datasources/proxy/:id.*|/api/ds/query|/api/tsdb/query",status_code=~"5.."}
+        /
+        ignoring(status_code)
+        group_left
         sum without (status_code) (namespace_job_handler_statuscode:grafana_http_request_duration_seconds_count:rate5m{handler!~"/api/datasources/proxy/:id.*|/api/ds/query|/api/tsdb/query"})
         > 50
       for: 5m


### PR DESCRIPTION
#### What this PR does / why we need it:
![image](https://user-images.githubusercontent.com/1277613/199462685-529f2cb2-631b-4ee6-9f9d-a5b8306a359c.png)

without `group_left`
![image](https://user-images.githubusercontent.com/1277613/199464380-a23c98e7-1219-4b59-a481-5d62a67abdad.png)

with `group_left`
![image](https://user-images.githubusercontent.com/1277613/199464742-e8371818-ea22-4283-99d2-6cb608f484b3.png)

result
![image](https://user-images.githubusercontent.com/1277613/199464842-95e8b8c1-e0a6-4c4a-a36b-14d6bd79d46e.png)

`group_right` results into a `many-to-many` which is not allowed

#### Which issue this PR fixes
- N/A

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[portefaix-kyverno]`)
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `ChangeLog.md` has beed updated
- [x] Variables are documented in the `README.md`