### PR TITLE
[secrets-store-csi-driver-provider-gcp] Update default image for secrets-store-csi-driver-provider-gcp to v1.2.0

### DIFF
--- a/charts/secrets-store-csi-driver-provider-gcp/Chart.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/Chart.yaml
@@ -31,12 +31,12 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.0.0
+appVersion: 1.2.0
 
 maintainers:
   - name: nlamirault
@@ -67,6 +67,3 @@ annotations:
       links:
         - name: Github Issue
           url: https://github.com/portefaix/portefaix-hub/pull/129
-
-
-

--- a/charts/secrets-store-csi-driver-provider-gcp/README.md
+++ b/charts/secrets-store-csi-driver-provider-gcp/README.md
@@ -1,6 +1,6 @@
 # secrets-store-csi-driver-provider-gcp
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 A Helm chart for Google Secret Manager Provider for Secret Store CSI Driver
 
@@ -26,7 +26,7 @@ A Helm chart for Google Secret Manager Provider for Secret Store CSI Driver
 | fullnameOverride | string | `""` | Provide a name to substitute for the full names of resources |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin"` |  |
-| image.tag | string | `"v1.0.0"` |  |
+| image.tag | string | `"v1.2.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | namespace | string | `"kube-system"` | Namespace to deploy the Secret Store CSI Driver |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment # Ref: https://kubernetes.io/docs/user-guide/node-selection/ |

--- a/charts/secrets-store-csi-driver-provider-gcp/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/values.yaml
@@ -35,7 +35,7 @@ namespace: kube-system
 
 image:
   repository: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin
-  tag: v1.0.0
+  tag: v1.2.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
#### What this PR does / why we need it:

For the [secrets-store-csi-driver-provider-gcp](https://github.com/portefaix/portefaix-hub/tree/master/charts/secrets-store-csi-driver-provider-gcp) Chart.

Updates the default version of the Docker image in [values.yaml](https://github.com/portefaix/portefaix-hub/blob/master/charts/secrets-store-csi-driver-provider-gcp/values.yaml) to the latest released version, [v1.2.0](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/releases/tag/v1.2.0).

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
N/A

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR starts with chart name (e.g. `[portefaix-kyverno]`)
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [ ] ~`ChangeLog.md` has beed updated~ N/A
- [ ] ~Variables are documented in the `README.md`~ N/A
