### PR TITLE
Update configmap-dashboards.yaml to include additionalLabels

### DIFF
--- a/charts/tempo-mixin/templates/configmap-dashboards.yaml
+++ b/charts/tempo-mixin/templates/configmap-dashboards.yaml
@@ -17,6 +17,9 @@ items:
     labels:
       grafana-dashboard: {{ $dashboardName }}
       {{- include "tempo-mixin.labels" $ | indent 6 }}
+      {{- if .Values.additionalLabels }}
+        {{- toYaml .Values.additionalLabels | nindent 6 }}
+      {{- end }}
   data:
     {{ $dashboardName }}.json: |-
 {{ $.Files.Get $path | indent 6}}


### PR DESCRIPTION
This commit adds `addtionalLabels` on the config map for each dashboard. Which I think was missing. 
