### PR TITLE
Adds addtional info to loki and tempo-mixin configmaps

### DIFF
--- a/charts/loki-mixin/Chart.yaml
+++ b/charts/loki-mixin/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
   - loki
   - monitoring-mixin
   - portefaix
-version: 1.4.0
+version: 1.5.0
 appVersion: 2.7.0
 
 maintainers:
@@ -52,4 +52,4 @@ annotations:
     url: https://keybase.io/nlamirault/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: loki-mixin v2.8.0
+      description: Includes additionalLabels and additionalAnnotations on configmaps

--- a/charts/loki-mixin/templates/_helpers.tpl
+++ b/charts/loki-mixin/templates/_helpers.tpl
@@ -52,6 +52,9 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "loki-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.additionalLabels }}
+{{- toYaml .Values.additionalLabels }}
+{{- end }}
 {{- end }}
 
 {{/* See: https://ambassadorlabs.github.io/k8s-for-humans/ */}}
@@ -65,6 +68,9 @@ a8r.io/bugs: https://github.com/portefaix/portefaix-hub/issues
 a8r.io/documentation: https://artifacthub.io/packages/helm/portefaix-hub/loki-mixin
 a8r.io/repository: https://github.com/portefaix/portefaix-hub
 a8r.io/support: https://github.com/portefaix/portefaix-hub/issues
+{{- if .Values.additionalAnnotations }}
+{{- toYaml .Values.additionalAnnotations }}
+{{- end }}
 {{- end }}
 
 {{/* a8r.io/logs: */}}

--- a/charts/tempo-mixin/Chart.yaml
+++ b/charts/tempo-mixin/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
   - tempo
   - monitoring-mixin
   - portefaix
-version: 1.3.0
+version: 1.4.0
 appVersion: 2.0.0
 
 maintainers:
@@ -52,4 +52,4 @@ annotations:
     url: https://keybase.io/nlamirault/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: tempo-mixin v2.0.1
+      description: Includes additionalLabels and additionalAnnotations on configmaps

--- a/charts/tempo-mixin/templates/_helpers.tpl
+++ b/charts/tempo-mixin/templates/_helpers.tpl
@@ -52,6 +52,9 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "tempo-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.additionalLabels }}
+{{- toYaml .Values.additionalLabels }}
+{{- end }}
 {{- end }}
 
 {{/* See: https://ambassadorlabs.github.io/k8s-for-humans/ */}}
@@ -65,6 +68,9 @@ a8r.io/bugs: https://github.com/portefaix/portefaix-hub/issues
 a8r.io/documentation: https://artifacthub.io/packages/helm/portefaix-hub/tempo-mixin
 a8r.io/repository: https://github.com/portefaix/portefaix-hub
 a8r.io/support: https://github.com/portefaix/portefaix-hub/issues
+{{- if .Values.additionalAnnotations }}
+{{- toYaml .Values.additionalAnnotations }}
+{{- end }}
 {{- end }}
 
 {{/* a8r.io/logs: */}}


### PR DESCRIPTION
This PR adds `addtionalAnnotations` and `annotationsLabels` to the config maps for the dashboard. 