### PR TITLE
[secrets-store-csi-driver-provider-gcp] Chart fixes and updates

### DIFF
--- a/charts/secrets-store-csi-driver-provider-gcp/Chart.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/Chart.yaml
@@ -31,12 +31,12 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.0.0
+appVersion: 1.5.0
 
 maintainers:
   - name: nlamirault

--- a/charts/secrets-store-csi-driver-provider-gcp/README.md
+++ b/charts/secrets-store-csi-driver-provider-gcp/README.md
@@ -1,6 +1,6 @@
 # secrets-store-csi-driver-provider-gcp
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 A Helm chart for Google Secret Manager Provider for Secret Store CSI Driver
 
@@ -8,36 +8,35 @@ A Helm chart for Google Secret Manager Provider for Secret Store CSI Driver
 
 ## Maintainers
 
-| Name       | Email                         | Url |
-| ---------- | ----------------------------- | --- |
-| nlamirault | <nicolas.lamirault@gmail.com> |     |
+| Name | Email | Url |
+| ---- | ------ | --- |
+| nlamirault | <nicolas.lamirault@gmail.com> |  |
 
 ## Source Code
 
-- <https://github.com/portefaix/portefaix-hub/tree/master/charts/secrets-store-csi-driver-provider-gcp>
+* <https://github.com/portefaix/portefaix-hub/tree/master/charts/secrets-store-csi-driver-provider-gcp>
 
 ## Values
 
-| Key                             | Type   | Default                                                                              | Description                                                                                                             |
-| ------------------------------- | ------ | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| additionalAnnotations           | object | `{}`                                                                                 | Additional annotations to add to metadata                                                                               |
-| additionalLabels                | object | `{}`                                                                                 | Additional labels to add to metadata                                                                                    |
-| affinity                        | object | `{}`                                                                                 | Affinity settings for pod assignment # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/          |
-| fullnameOverride                | string | `""`                                                                                 | Provide a name to substitute for the full names of resources                                                            |
-| image.pullPolicy                | string | `"IfNotPresent"`                                                                     |                                                                                                                         |
-| image.repository                | string | `"us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin"` |                                                                                                                         |
-| image.tag                       | string | `"v1.0.0"`                                                                           |                                                                                                                         |
-| imagePullSecrets                | list   | `[]`                                                                                 |                                                                                                                         |
-| namespace                       | string | `"kube-system"`                                                                      | Namespace to deploy the Secret Store CSI Driver                                                                         |
-| nodeSelector                    | object | `{"kubernetes.io/os":"linux"}`                                                       | Node labels for pod assignment # Ref: https://kubernetes.io/docs/user-guide/node-selection/                             |
-| rbac.create                     | bool   | `true`                                                                               | If true, create & use RBAC resources                                                                                    |
-| resources                       | object | `{}`                                                                                 | Container resources (requests and limits for cpu and memory)                                                            |
-| serviceAccount.annotations      | object | `{}`                                                                                 | ServiceAccount annotations. # Use case: GKE Workload Identity for service accounts                                      |
-| serviceAccount.create           | bool   | `true`                                                                               | Specifies whether a ServiceAccount should be created, require rbac true                                                 |
-| serviceAccount.imagePullSecrets | list   | `[]`                                                                                 |                                                                                                                         |
-| serviceAccount.name             | string | `nil`                                                                                | The name of the ServiceAccount to use. # If not set and create is true, a name is generated using the fullname template |
-| tolerations                     | list   | `[]`                                                                                 | Tolerations for pod assignment # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/           |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| additionalAnnotations | object | `{}` | Additional annotations to add to metadata |
+| additionalLabels | object | `{}` | Additional labels to add to metadata |
+| affinity | object | `{}` | Affinity settings for pod assignment # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
+| fullnameOverride | string | `""` | Provide a name to substitute for the full names of resources |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin"` |  |
+| image.tag | string | `"v1.5.0"` |  |
+| imagePullSecrets | list | `[]` |  |
+| namespace | string | `"kube-system"` | Namespace to deploy the Secret Store CSI Driver |
+| nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment # Ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| rbac.create | bool | `true` | If true, create & use RBAC resources |
+| resources | object | `{}` | Container resources (requests and limits for cpu and memory) |
+| serviceAccount.annotations | object | `{}` | ServiceAccount annotations. # Use case: GKE Workload Identity for service accounts |
+| serviceAccount.create | bool | `true` | Specifies whether a ServiceAccount should be created, require rbac true |
+| serviceAccount.imagePullSecrets | list | `[]` |  |
+| serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. # If not set and create is true, a name is generated using the fullname template |
+| tolerations | list | `[]` | Tolerations for pod assignment # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 
----
-
-Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.13.1](https://github.com/norwoodj/helm-docs/releases/v1.13.1)

--- a/charts/secrets-store-csi-driver-provider-gcp/templates/clusterrole.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/clusterrole.yaml
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/secrets-store-csi-driver-provider-gcp/templates/clusterrolebinding.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/clusterrolebinding.yaml
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.rbac.create -}}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/daemonset.yaml
@@ -37,10 +37,33 @@ spec:
         {{- include "secrets-store-csi-driver-provider-gcp.labels" . | indent 8 }}
     spec:
       serviceAccountName: {{ template "secrets-store-csi-driver-provider-gcp.serviceAccountName" . }}
+      initContainers:
+      - name: chown-provider-mount
+        image: busybox
+        command:
+        - chown
+        - "1000:1000"
+        - /etc/kubernetes/secrets-store-csi-providers
+        volumeMounts:
+        - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+          name: providervol
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+              - ALL
 {{- if .Values.resources }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
@@ -51,9 +74,8 @@ spec:
           volumeMounts:
             - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
               name: providervol
-            - name: mountpoint-dir
-              mountPath: /var/lib/kubelet/pods
-              mountPropagation: HostToContainer
+              mountPropagation: None
+              readOnly: false
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -62,6 +84,10 @@ spec:
             initialDelaySeconds: 5
             timeoutSeconds: 10
             periodSeconds: 30
+      volumes:
+        - name: providervol
+          hostPath:
+            path: /etc/kubernetes/secrets-store-csi-providers
 {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
@@ -74,11 +100,3 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- end }}
-      volumes:
-        - name: providervol
-          hostPath:
-              path: /etc/kubernetes/secrets-store-csi-providers
-        - name: mountpoint-dir
-          hostPath:
-            path: /var/lib/kubelet/pods
-            type: DirectoryOrCreate

--- a/charts/secrets-store-csi-driver-provider-gcp/templates/serviceaccount.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/templates/serviceaccount.yaml
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/secrets-store-csi-driver-provider-gcp/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-gcp/values.yaml
@@ -35,7 +35,7 @@ namespace: kube-system
 
 image:
   repository: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin
-  tag: v1.4.0
+  tag: v1.5.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
#### What this PR does / why we need it:

- Fixes a chart rendering error in a few templates, the `-}}` just before the start of the resource template chomps the newline and means the `apiVersion` field of the resource ends up as part of the header comment.
  - pre fix:
      ```shell
      ➜  helm template . -f values.yaml | kubeconform -kubernetes-version "1.27.8" -summary -ignore-missing-schemas -schema-location default
      stdin - ServiceAccount release-name-secrets-store-csi-driver-provider-gcp failed validation: error while parsing: missing 'apiVersion' key
      stdin - ClusterRole release-name-secrets-store-csi-driver-provider-gcp failed validation: error while parsing: missing 'apiVersion' key
      stdin - ClusterRoleBinding release-name-secrets-store-csi-driver-provider-gcp failed validation: error while parsing: missing 'apiVersion' key
      Summary: 4 resources found parsing stdin - Valid: 1, Invalid: 0, Errors: 3, Skipped: 0
      ```
  - post fix:
      ```shell
      ➜  helm template . -f values.yaml | kubeconform -kubernetes-version "1.27.8" -summary -ignore-missing-schemas -schema-location default
      Summary: 4 resources found parsing stdin - Valid: 4, Invalid: 0, Errors: 0, Skipped: 0
      ```
- Bump the default application version to 1.5.0
- Bring the [various security improvements](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/commits/main/charts/secrets-store-csi-driver-provider-gcp) that have been added to the Chart in the [application repo](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp)

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

- The `mountpoint-dir` volume is no [longer needed since v1.0.0 of the application](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/blob/e4e5645cc33bd5c8a8d00c77c799a7c74c2dd3a1/CHANGELOG.md#v100)

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the PR starts with chart name (e.g. `[portefaix-kyverno]`)
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] Variables are documented in the `README.md`
