### PR TITLE
Fix missing loki-mixin.annotations and pyroscope-mixin.annotations in respective _helpers.yaml

### DIFF
--- a/charts/loki-mixin/Chart.yaml
+++ b/charts/loki-mixin/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
   - loki
   - monitoring-mixin
   - portefaix
-version: 1.9.0
+version: 1.10.0
 appVersion: 3.3.0
 
 maintainers:

--- a/charts/loki-mixin/templates/_helpers.tpl
+++ b/charts/loki-mixin/templates/_helpers.tpl
@@ -57,6 +57,16 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 {{- end }}
 
+{{/* See: https://ambassadorlabs.github.io/k8s-for-humans/ */}}
+{{/*
+Common annotations
+*/}}
+{{- define "loki-mixin.annotations" }}
+{{- if .Values.additionalAnnotations }}
+{{ toYaml .Values.additionalAnnotations }}
+{{- end }}
+{{- end }}
+
 {{/*
 Allow the release namespace to be overridden
 */}}

--- a/charts/pyroscope-mixin/Chart.yaml
+++ b/charts/pyroscope-mixin/Chart.yaml
@@ -28,7 +28,7 @@ keywords:
   - kubernetes
   - monitoring-mixin
   - portefaix
-version: 1.5.0
+version: 1.6.0
 appVersion: 1.10.0
 maintainers:
   - name: nlamirault

--- a/charts/pyroscope-mixin/templates/_helpers.tpl
+++ b/charts/pyroscope-mixin/templates/_helpers.tpl
@@ -57,6 +57,16 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 {{- end }}
 
+{{/* See: https://ambassadorlabs.github.io/k8s-for-humans/ */}}
+{{/*
+Common annotations
+*/}}
+{{- define "pyroscope-mixin.annotations" }}
+{{- if .Values.additionalAnnotations }}
+{{ toYaml .Values.additionalAnnotations }}
+{{- end }}
+{{- end }}
+
 {{/*
 Allow the release namespace to be overridden
 */}}


### PR DESCRIPTION
This pull request includes updates to the `loki-mixin` and `pyroscope-mixin` Helm charts. The most important changes include version bumps and the addition of common annotations.

Version updates:

* [`charts/loki-mixin/Chart.yaml`](diffhunk://#diff-abbb9dfcb85afbefe398048251d753a5c9a8b58d5872cb6d131951815ed006f3L30-R30): Updated the version from `1.9.0` to `1.10.0`.
* [`charts/pyroscope-mixin/Chart.yaml`](diffhunk://#diff-8f22259f3a17b6864caea79d15e1ab4ba58f79c2e27c92ed50ee588cfe405fb0L31-R31): Updated the version from `1.5.0` to `1.6.0`.

Annotations:

* [`charts/loki-mixin/templates/_helpers.tpl`](diffhunk://#diff-ff38241c645dc5e8cb0d7b10f763c4f5f72dbec61af40fd696bde039eb79b7beR60-R69): Added a new template `loki-mixin.annotations` for common annotations.
* [`charts/pyroscope-mixin/templates/_helpers.tpl`](diffhunk://#diff-7482cfb41ed4e5a5a7dabc82a574fa5ad76f27de92ccd8c5aed979ec5a4a5fd5R60-R69): Added a new template `pyroscope-mixin.annotations` for common annotations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgraded the Helm chart versions for both Loki and Pyroscope mixins, reflecting new releases.
  - Introduced support for custom annotations in both mixins, enabling flexible configuration of additional annotations via chart values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->