### PR TITLE
[portefaix-mixins] fix(charts): remove redundant component label from helper templates

### DIFF
--- a/charts/alertmanager-mixin/Changelog.md
+++ b/charts/alertmanager-mixin/Changelog.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 1.10.1
+
+**Release date:** 2026-02-26
+
+![AppVersion: 0.27.0](https://img.shields.io/static/v1?label=AppVersion&message=0.27.0&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+- fix(charts): remove redundant component label from helper templates
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
 ## 0.3.0
 
 **Release date:** 2021-08-31

--- a/charts/alertmanager-mixin/Chart.yaml
+++ b/charts/alertmanager-mixin/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
   - alertmanager
   - monitoring-mixin
   - portefaix
-version: 1.10.0
+version: 1.10.1
 appVersion: 0.27.0
 
 maintainers:

--- a/charts/alertmanager-mixin/README.md
+++ b/charts/alertmanager-mixin/README.md
@@ -1,6 +1,6 @@
 # alertmanager-mixin
 
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.0](https://img.shields.io/badge/AppVersion-0.27.0-informational?style=flat-square)
+![Version: 1.10.1](https://img.shields.io/badge/Version-1.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.0](https://img.shields.io/badge/AppVersion-0.27.0-informational?style=flat-square)
 
 A Helm chart for Alertmanager Mixin
 

--- a/charts/alertmanager-mixin/templates/_helpers.tpl
+++ b/charts/alertmanager-mixin/templates/_helpers.tpl
@@ -49,7 +49,6 @@ helm.sh/chart: {{ include "alertmanager-mixin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "alertmanager-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ if .Values.additionalLabels -}}

--- a/charts/alloy-mixin/Changelog.md
+++ b/charts/alloy-mixin/Changelog.md
@@ -1,0 +1,17 @@
+# Change Log
+
+## 0.3.3
+
+**Release date:** 2026-02-26
+
+![AppVersion: 1.5.0](https://img.shields.io/static/v1?label=AppVersion&message=1.5.0&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+- fix(charts): remove redundant component label from helper templates
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+

--- a/charts/alloy-mixin/Chart.yaml
+++ b/charts/alloy-mixin/Chart.yaml
@@ -29,7 +29,7 @@ keywords:
   - prometheus
   - monitoring-mixin
   - portefaix
-version: 0.3.2
+version: 0.3.3
 appVersion: 1.5.0
 
 maintainers:

--- a/charts/alloy-mixin/README.md
+++ b/charts/alloy-mixin/README.md
@@ -1,6 +1,6 @@
 # alloy-mixin
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 A Helm chart for Alloy mixin
 

--- a/charts/alloy-mixin/templates/_helpers.tpl
+++ b/charts/alloy-mixin/templates/_helpers.tpl
@@ -49,7 +49,6 @@ helm.sh/chart: {{ include "alloy-mixin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "alloy-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.additionalLabels }}

--- a/charts/coredns-mixin/Changelog.md
+++ b/charts/coredns-mixin/Changelog.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 1.5.1
+
+**Release date:** 2026-02-26
+
+![AppVersion: master](https://img.shields.io/static/v1?label=AppVersion&message=master&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+- fix(charts): remove redundant component label from helper templates
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
 ## 0.1.0
 
 **Release date:** 2021-09-01

--- a/charts/coredns-mixin/Chart.yaml
+++ b/charts/coredns-mixin/Chart.yaml
@@ -28,7 +28,7 @@ keywords:
   - prometheus
   - monitoring-mixin
   - portefaix
-version: 1.5.0
+version: 1.5.1
 appVersion: master
 
 maintainers:

--- a/charts/coredns-mixin/README.md
+++ b/charts/coredns-mixin/README.md
@@ -1,6 +1,6 @@
 # coredns-mixin
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for CoreDNS Mixin
 

--- a/charts/coredns-mixin/templates/_helpers.tpl
+++ b/charts/coredns-mixin/templates/_helpers.tpl
@@ -49,7 +49,6 @@ helm.sh/chart: {{ include "coredns-mixin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "coredns-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.additionalLabels }}

--- a/charts/fluxcd-mixin/Changelog.md
+++ b/charts/fluxcd-mixin/Changelog.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 1.2.1
+
+**Release date:** 2026-02-26
+
+![AppVersion: master](https://img.shields.io/static/v1?label=AppVersion&message=master&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+- fix(charts): remove redundant component label from helper templates
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
 ## 0.1.0
 
 **Release date:** 2021-08-31

--- a/charts/fluxcd-mixin/Chart.yaml
+++ b/charts/fluxcd-mixin/Chart.yaml
@@ -31,7 +31,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fluxcd-mixin/README.md
+++ b/charts/fluxcd-mixin/README.md
@@ -1,6 +1,6 @@
 # fluxcd-mixin
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for FluxCD Mixin
 

--- a/charts/fluxcd-mixin/templates/_helpers.tpl
+++ b/charts/fluxcd-mixin/templates/_helpers.tpl
@@ -49,7 +49,6 @@ helm.sh/chart: {{ include "fluxcd-mixin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "fluxcd-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}

--- a/charts/grafana-mixin/Changelog.md
+++ b/charts/grafana-mixin/Changelog.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 1.5.1
+
+**Release date:** 2026-02-26
+
+![AppVersion: 11.3.1](https://img.shields.io/static/v1?label=AppVersion&message=11.3.1&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+- fix(charts): remove redundant component label from helper templates
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
 ## 0.8.0
 
 **Release date:** 2021-08-31

--- a/charts/grafana-mixin/Chart.yaml
+++ b/charts/grafana-mixin/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
   - grafana
   - monitoring-mixin
   - portefaix
-version: 1.5.0
+version: 1.5.1
 appVersion: 11.3.1
 
 maintainers:

--- a/charts/grafana-mixin/README.md
+++ b/charts/grafana-mixin/README.md
@@ -1,6 +1,6 @@
 # grafana-mixin
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 11.3.1](https://img.shields.io/badge/AppVersion-11.3.1-informational?style=flat-square)
+![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 11.3.1](https://img.shields.io/badge/AppVersion-11.3.1-informational?style=flat-square)
 
 A Helm chart for Grafana Mixin
 

--- a/charts/grafana-mixin/templates/_helpers.tpl
+++ b/charts/grafana-mixin/templates/_helpers.tpl
@@ -49,7 +49,6 @@ helm.sh/chart: {{ include "grafana-mixin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "grafana-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}

--- a/charts/kube-state-metrics-mixin/Changelog.md
+++ b/charts/kube-state-metrics-mixin/Changelog.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 1.3.1
+
+**Release date:** 2026-02-26
+
+![AppVersion: 2.13.0](https://img.shields.io/static/v1?label=AppVersion&message=2.13.0&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+- fix(charts): remove redundant component label from helper templates
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
 ## 0.7.0
 
 **Release date:** 2021-08-31

--- a/charts/kube-state-metrics-mixin/Chart.yaml
+++ b/charts/kube-state-metrics-mixin/Chart.yaml
@@ -31,7 +31,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kube-state-metrics-mixin/README.md
+++ b/charts/kube-state-metrics-mixin/README.md
@@ -1,6 +1,6 @@
 # kube-state-metrics-mixin
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.13.0](https://img.shields.io/badge/AppVersion-2.13.0-informational?style=flat-square)
+![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.13.0](https://img.shields.io/badge/AppVersion-2.13.0-informational?style=flat-square)
 
 A Helm chart for Kube-State-Metrics Mixin
 

--- a/charts/kube-state-metrics-mixin/templates/_helpers.tpl
+++ b/charts/kube-state-metrics-mixin/templates/_helpers.tpl
@@ -49,7 +49,6 @@ helm.sh/chart: {{ include "kube-state-metrics-mixin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "kube-state-metrics-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}

--- a/charts/kubernetes-mixin/Changelog.md
+++ b/charts/kubernetes-mixin/Changelog.md
@@ -1,0 +1,17 @@
+# Change Log
+
+## 1.5.2
+
+**Release date:** 2026-02-26
+
+![AppVersion: master](https://img.shields.io/static/v1?label=AppVersion&message=master&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+- fix(charts): remove redundant component label from helper templates
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+

--- a/charts/kubernetes-mixin/Chart.yaml
+++ b/charts/kubernetes-mixin/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
   - kubernetes
   - monitoring-mixin
   - portefaix
-version: 1.5.1
+version: 1.5.2
 appVersion: master
 
 maintainers:

--- a/charts/kubernetes-mixin/README.md
+++ b/charts/kubernetes-mixin/README.md
@@ -1,6 +1,6 @@
 # kubernetes-mixin
 
-![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 1.5.2](https://img.shields.io/badge/Version-1.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for Kubernetes Mixin
 

--- a/charts/kubernetes-mixin/templates/_helpers.tpl
+++ b/charts/kubernetes-mixin/templates/_helpers.tpl
@@ -49,7 +49,6 @@ helm.sh/chart: {{ include "kubernetes-mixin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "kubernetes-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.additionalLabels }}

--- a/charts/loki-mixin/Changelog.md
+++ b/charts/loki-mixin/Changelog.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 1.10.1
+
+**Release date:** 2026-02-26
+
+![AppVersion: 3.3.0](https://img.shields.io/static/v1?label=AppVersion&message=3.3.0&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+- fix(charts): remove redundant component label from helper templates
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
 ## 0.9.0
 
 **Release date:** 2021-08-31

--- a/charts/loki-mixin/Chart.yaml
+++ b/charts/loki-mixin/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
   - loki
   - monitoring-mixin
   - portefaix
-version: 1.10.0
+version: 1.10.1
 appVersion: 3.3.0
 
 maintainers:

--- a/charts/loki-mixin/README.md
+++ b/charts/loki-mixin/README.md
@@ -1,6 +1,6 @@
 # loki-mixin
 
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
+![Version: 1.10.1](https://img.shields.io/badge/Version-1.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
 
 A Helm chart for Loki Mixin
 

--- a/charts/loki-mixin/templates/_helpers.tpl
+++ b/charts/loki-mixin/templates/_helpers.tpl
@@ -49,7 +49,6 @@ helm.sh/chart: {{ include "loki-mixin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "loki-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.additionalLabels }}

--- a/charts/mimir-mixin/Changelog.md
+++ b/charts/mimir-mixin/Changelog.md
@@ -1,0 +1,17 @@
+# Change Log
+
+## 1.7.2
+
+**Release date:** 2026-02-26
+
+![AppVersion: 2.9.0](https://img.shields.io/static/v1?label=AppVersion&message=2.9.0&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+- fix(charts): remove redundant component label from helper templates
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+

--- a/charts/mimir-mixin/Chart.yaml
+++ b/charts/mimir-mixin/Chart.yaml
@@ -28,7 +28,7 @@ keywords:
   - monitoring-mixin
   - mimir
   - portefaix
-version: 1.7.1
+version: 1.7.2
 appVersion: 2.9.0
 
 maintainers:

--- a/charts/mimir-mixin/README.md
+++ b/charts/mimir-mixin/README.md
@@ -1,6 +1,6 @@
 # mimir-mixin
 
-![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
+![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.0](https://img.shields.io/badge/AppVersion-2.9.0-informational?style=flat-square)
 
 A Helm chart for Grafana Mimir mixin
 

--- a/charts/mimir-mixin/templates/_helpers.tpl
+++ b/charts/mimir-mixin/templates/_helpers.tpl
@@ -49,7 +49,6 @@ helm.sh/chart: {{ include "mimir-mixin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "mimir-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.additionalLabels }}

--- a/charts/node-exporter-mixin/Changelog.md
+++ b/charts/node-exporter-mixin/Changelog.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 1.4.1
+
+**Release date:** 2026-02-26
+
+![AppVersion: 1.7.0](https://img.shields.io/static/v1?label=AppVersion&message=1.7.0&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+- fix(charts): remove redundant component label from helper templates
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
 ## 0.1.0
 
 **Release date:** 2021-09-01

--- a/charts/node-exporter-mixin/Chart.yaml
+++ b/charts/node-exporter-mixin/Chart.yaml
@@ -32,7 +32,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/node-exporter-mixin/README.md
+++ b/charts/node-exporter-mixin/README.md
@@ -1,6 +1,6 @@
 # node-exporter-mixin
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
+![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 
 A Helm chart for Alertmanager Mixin
 

--- a/charts/node-exporter-mixin/templates/_helpers.tpl
+++ b/charts/node-exporter-mixin/templates/_helpers.tpl
@@ -49,7 +49,6 @@ helm.sh/chart: {{ include "node-exporter-mixin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "node-exporter-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.additionalLabels }}

--- a/charts/prometheus-mixin/Changelog.md
+++ b/charts/prometheus-mixin/Changelog.md
@@ -1,0 +1,17 @@
+# Change Log
+
+## 1.5.1
+
+**Release date:** 2026-02-26
+
+![AppVersion: 2.54.1](https://img.shields.io/static/v1?label=AppVersion&message=2.54.1&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+- fix(charts): remove redundant component label from helper templates
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+

--- a/charts/prometheus-mixin/Chart.yaml
+++ b/charts/prometheus-mixin/Chart.yaml
@@ -31,7 +31,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-mixin/README.md
+++ b/charts/prometheus-mixin/README.md
@@ -1,6 +1,6 @@
 # prometheus-mixin
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.54.1](https://img.shields.io/badge/AppVersion-2.54.1-informational?style=flat-square)
+![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.54.1](https://img.shields.io/badge/AppVersion-2.54.1-informational?style=flat-square)
 
 A Helm chart for Prometheus Mixin
 

--- a/charts/prometheus-mixin/templates/_helpers.tpl
+++ b/charts/prometheus-mixin/templates/_helpers.tpl
@@ -49,7 +49,6 @@ helm.sh/chart: {{ include "prometheus-mixin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "prometheus-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}

--- a/charts/prometheus-operator-mixin/Changelog.md
+++ b/charts/prometheus-operator-mixin/Changelog.md
@@ -1,0 +1,17 @@
+# Change Log
+
+## 1.4.1
+
+**Release date:** 2026-02-26
+
+![AppVersion: 0.78.2](https://img.shields.io/static/v1?label=AppVersion&message=0.78.2&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+- fix(charts): remove redundant component label from helper templates
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+

--- a/charts/prometheus-operator-mixin/Chart.yaml
+++ b/charts/prometheus-operator-mixin/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
   - prometheus-operator
   - monitoring-mixin
   - portefaix
-version: 1.4.0
+version: 1.4.1
 appVersion: 0.78.2
 
 maintainers:

--- a/charts/prometheus-operator-mixin/README.md
+++ b/charts/prometheus-operator-mixin/README.md
@@ -1,6 +1,6 @@
 # prometheus-operator-mixin
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.78.2](https://img.shields.io/badge/AppVersion-0.78.2-informational?style=flat-square)
+![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.78.2](https://img.shields.io/badge/AppVersion-0.78.2-informational?style=flat-square)
 
 A Helm chart for Prometheus Operator Mixin
 

--- a/charts/prometheus-operator-mixin/templates/_helpers.tpl
+++ b/charts/prometheus-operator-mixin/templates/_helpers.tpl
@@ -49,7 +49,6 @@ helm.sh/chart: {{ include "prometheus-operator-mixin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "prometheus-operator-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}

--- a/charts/promtail-mixin/Changelog.md
+++ b/charts/promtail-mixin/Changelog.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 1.7.1
+
+**Release date:** 2026-02-26
+
+![AppVersion: 2.9.3](https://img.shields.io/static/v1?label=AppVersion&message=2.9.3&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+- fix(charts): remove redundant component label from helper templates
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
 ## 0.9.0
 
 **Release date:** 2021-08-31

--- a/charts/promtail-mixin/Chart.yaml
+++ b/charts/promtail-mixin/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
   - promtail
   - monitoring-mixin
   - portefaix
-version: 1.7.0
+version: 1.7.1
 appVersion: 2.9.3
 
 maintainers:

--- a/charts/promtail-mixin/README.md
+++ b/charts/promtail-mixin/README.md
@@ -1,6 +1,6 @@
 # promtail-mixin
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.3](https://img.shields.io/badge/AppVersion-2.9.3-informational?style=flat-square)
+![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.3](https://img.shields.io/badge/AppVersion-2.9.3-informational?style=flat-square)
 
 A Helm chart for Promtail Mixin
 

--- a/charts/promtail-mixin/templates/_helpers.tpl
+++ b/charts/promtail-mixin/templates/_helpers.tpl
@@ -49,7 +49,6 @@ helm.sh/chart: {{ include "promtail-mixin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "promtail-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}

--- a/charts/pyroscope-mixin/Changelog.md
+++ b/charts/pyroscope-mixin/Changelog.md
@@ -1,0 +1,17 @@
+# Change Log
+
+## 1.6.1
+
+**Release date:** 2026-02-26
+
+![AppVersion: 1.10.0](https://img.shields.io/static/v1?label=AppVersion&message=1.10.0&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+- fix(charts): remove redundant component label from helper templates
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+

--- a/charts/pyroscope-mixin/Chart.yaml
+++ b/charts/pyroscope-mixin/Chart.yaml
@@ -28,7 +28,7 @@ keywords:
   - kubernetes
   - monitoring-mixin
   - portefaix
-version: 1.6.0
+version: 1.6.1
 appVersion: 1.10.0
 maintainers:
   - name: nlamirault

--- a/charts/pyroscope-mixin/README.md
+++ b/charts/pyroscope-mixin/README.md
@@ -1,6 +1,6 @@
 # pyroscope-mixin
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
+![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
 
 A Helm chart for Grafana Pyroscope mixin
 

--- a/charts/pyroscope-mixin/templates/_helpers.tpl
+++ b/charts/pyroscope-mixin/templates/_helpers.tpl
@@ -49,7 +49,6 @@ helm.sh/chart: {{ include "pyroscope-mixin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "pyroscope-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.additionalLabels }}

--- a/charts/tempo-mixin/Changelog.md
+++ b/charts/tempo-mixin/Changelog.md
@@ -1,0 +1,17 @@
+# Change Log
+
+## 1.9.2
+
+**Release date:** 2026-02-26
+
+![AppVersion: 2.6.1](https://img.shields.io/static/v1?label=AppVersion&message=2.6.1&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+- fix(charts): remove redundant component label from helper templates
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+

--- a/charts/tempo-mixin/Chart.yaml
+++ b/charts/tempo-mixin/Chart.yaml
@@ -27,7 +27,7 @@ keywords:
   - tempo
   - monitoring-mixin
   - portefaix
-version: 1.9.1
+version: 1.9.2
 appVersion: 2.6.1
 
 maintainers:

--- a/charts/tempo-mixin/README.md
+++ b/charts/tempo-mixin/README.md
@@ -1,6 +1,6 @@
 # tempo-mixin
 
-![Version: 1.9.1](https://img.shields.io/badge/Version-1.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 1.9.2](https://img.shields.io/badge/Version-1.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 A Helm chart for Grafana Tempo mixin
 

--- a/charts/tempo-mixin/templates/_helpers.tpl
+++ b/charts/tempo-mixin/templates/_helpers.tpl
@@ -49,7 +49,6 @@ helm.sh/chart: {{ include "tempo-mixin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "tempo-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.additionalLabels }}

--- a/charts/thanos-mixin/Changelog.md
+++ b/charts/thanos-mixin/Changelog.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 1.3.1
+
+**Release date:** 2026-02-26
+
+![AppVersion: 0.32.4](https://img.shields.io/static/v1?label=AppVersion&message=0.32.4&color=success&logo=)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+- fix(charts): remove redundant component label from helper templates
+
+### Default value changes
+
+```diff
+# No changes in this release
+```
+
 ## 0.14.1
 
 **Release date:** 2021-12-10

--- a/charts/thanos-mixin/Chart.yaml
+++ b/charts/thanos-mixin/Chart.yaml
@@ -31,7 +31,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/thanos-mixin/README.md
+++ b/charts/thanos-mixin/README.md
@@ -1,6 +1,6 @@
 # thanos-mixin
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.32.4](https://img.shields.io/badge/AppVersion-0.32.4-informational?style=flat-square)
+![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.32.4](https://img.shields.io/badge/AppVersion-0.32.4-informational?style=flat-square)
 
 A Helm chart for Thanos Mixin
 

--- a/charts/thanos-mixin/templates/_helpers.tpl
+++ b/charts/thanos-mixin/templates/_helpers.tpl
@@ -49,7 +49,6 @@ helm.sh/chart: {{ include "thanos-mixin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/component: monitoring-mixin
 app.kubernetes.io/part-of: {{ include "thanos-mixin.name" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.additionalLabels }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR removes the redundant `app.kubernetes.io/component: monitoring-mixin` label from the helper templates (`_helpers.tpl`) across all mixin-based Helm charts. 

**Why:**
This hardcoded label was being included in the common labels helper, leading to duplication when specific resource templates defined their own component labels. These duplicate keys caused issues during YAML post-rendering and with certain GitOps tooling that strictly validates Kubernetes manifests. By removing it from the global helpers, we allow for cleaner manifest generation and better compatibility with post-rendering workflows.

The change affects the following charts:
- `alertmanager-mixin`
- `alloy-mixin`
- `coredns-mixin`
- `fluxcd-mixin`
- `grafana-mixin`
- `kube-state-metrics-mixin`
- `kubernetes-mixin`
- `loki-mixin`
- `mimir-mixin`
- `node-exporter-mixin`
- `prometheus-mixin`
- `prometheus-operator-mixin`
- `promtail-mixin`
- `pyroscope-mixin`
- `tempo-mixin`
- `thanos-mixin`

#### Which issue this PR fixes

- fixes #

#### Special notes for your reviewer:

This is a refactoring fix that touches multiple charts simultaneously. Please ensure that the removal of this label doesn't conflict with any specific selectors that might have relied on this generic component label (though standard practice suggests using the `name` or `instance` labels for selectors).

#### Checklist

- [x] Title of the PR starts with chart name (e.g. `[portefaix-mixins]`)
- [x] Documentation has been updated with helm-docs (run: `.github/helm-docs.sh`)
- [x] Chart Version bumped
- [x] `ChangeLog.md` has been updated
- [x] Variables are documented in the `README.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a redundant component label emitted by multiple Helm chart templates, reducing duplicate metadata on deployed resources.

* **Chores**
  * Bumped patch versions across affected charts and added corresponding changelog entries.
  * Updated README version badges and removed a few obsolete source-link lines to keep documentation consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->